### PR TITLE
Added test case to improve code coverage

### DIFF
--- a/tests/CodiceFiscaleTest.php
+++ b/tests/CodiceFiscaleTest.php
@@ -32,9 +32,9 @@ class CodiceFiscaleTest extends TestCase
     function test_checker_can_detect_badCodes($badFiscalCode)
     {
         $chk = new CodiceFiscale();
-        
+
         self::assertFalse($chk->validaCodiceFiscale($badFiscalCode), $chk->getErrore() ?? "");
-        
+
         self::assertTrue(empty($chk->getGiornoNascita()), 'not empty getGiornoNascita');
         self::assertTrue(empty($chk->getMeseNascita()), 'not empty getMeseNascita');
         self::assertTrue(empty($chk->getAnnoNascita()), 'not empty getAnnoNascita');
@@ -97,6 +97,11 @@ class CodiceFiscaleTest extends TestCase
         return [
             [
                 ""
+            ],
+            [
+                "!NTPTR60C29H5L1W"
+            ],            [
+                "0NTPTR60C29H5L1S"
             ],
             [
                 "MRARSS82M56F205IXXXX"


### PR DESCRIPTION
The missing case was 0NTPTR60C29H5L1S, which has a good check digit, but has a number in a place reserved to letters.
I added a new test case too, just to show that non alphanumeric chars are fornidden 